### PR TITLE
Implement basic password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Visit `http://localhost:3000` to see the login page. The main routes are:
 
 - `/` – log in
 - `/signup` – registration form
+- `/forgot` – request password reset (link logged to console)
+- `/reset/:token` – set a new password
 - `/dashboard` – protected dashboard (requires authentication)
 - `/logout` – end the session
 

--- a/app/controllers/passwordResetController.js
+++ b/app/controllers/passwordResetController.js
@@ -1,0 +1,79 @@
+const crypto = require('crypto');
+const bcrypt = require('bcrypt');
+const Model = require('../model/models.js');
+
+module.exports.showForgot = function(req, res) {
+  res.render('forgot');
+};
+
+module.exports.handleForgot = function(req, res) {
+  const username = req.body.username;
+  if (!username) {
+    req.flash('error', 'Please provide a username.');
+    return res.redirect('/forgot');
+  }
+  Model.User.findOne({ where: { username } }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'No user found.');
+      return res.redirect('/forgot');
+    }
+    const token = crypto.randomBytes(20).toString('hex');
+    const expires = Date.now() + 3600000; // 1 hour
+    user.resetToken = token;
+    user.resetTokenExpires = new Date(expires);
+    user.save().then(function() {
+      console.log('Password reset link: http://localhost:3000/reset/' + token);
+      req.flash('error', 'Check console for reset link.');
+      res.redirect('/');
+    });
+  });
+};
+
+module.exports.showReset = function(req, res) {
+  Model.User.findOne({
+    where: {
+      resetToken: req.params.token,
+      resetTokenExpires: { $gt: new Date() }
+    }
+  }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'Password reset token is invalid or has expired.');
+      return res.redirect('/forgot');
+    }
+    res.render('reset', { token: req.params.token });
+  });
+};
+
+module.exports.handleReset = function(req, res) {
+  const password = req.body.password;
+  const password2 = req.body.password2;
+  if (!password || !password2) {
+    req.flash('error', 'Please fill in all fields.');
+    return res.redirect('back');
+  }
+  if (password !== password2) {
+    req.flash('error', 'Passwords do not match.');
+    return res.redirect('back');
+  }
+  Model.User.findOne({
+    where: {
+      resetToken: req.params.token,
+      resetTokenExpires: { $gt: new Date() }
+    }
+  }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'Password reset token is invalid or has expired.');
+      return res.redirect('/forgot');
+    }
+    const salt = bcrypt.genSaltSync(10);
+    const hashedPassword = bcrypt.hashSync(password, salt);
+    user.password = hashedPassword;
+    user.salt = salt;
+    user.resetToken = null;
+    user.resetTokenExpires = null;
+    user.save().then(function() {
+      req.flash('error', 'Password has been reset.');
+      res.redirect('/');
+    });
+  });
+};

--- a/app/model/User.js
+++ b/app/model/User.js
@@ -26,6 +26,12 @@ var attributes = {
   },
   salt: {
     type: Sequelize.STRING
+  },
+  resetToken: {
+    type: Sequelize.STRING
+  },
+  resetTokenExpires: {
+    type: Sequelize.DATE
   }
 }
 

--- a/app/routers/appRouter.js
+++ b/app/routers/appRouter.js
@@ -1,5 +1,6 @@
 var passport = require('passport'),
-    signupController = require('../controllers/signupController.js')
+    signupController = require('../controllers/signupController.js'),
+    passwordResetController = require('../controllers/passwordResetController.js')
 
 module.exports = function(express) {
   var router = express.Router()
@@ -13,6 +14,11 @@ module.exports = function(express) {
   
   router.get('/signup', signupController.show)
   router.post('/signup', signupController.signup)
+
+  router.get('/forgot', passwordResetController.showForgot)
+  router.post('/forgot', passwordResetController.handleForgot)
+  router.get('/reset/:token', passwordResetController.showReset)
+  router.post('/reset/:token', passwordResetController.handleReset)
 
   router.post('/login', passport.authenticate('local', {
       successRedirect: '/dashboard',

--- a/tests/utils/cleanup.js
+++ b/tests/utils/cleanup.js
@@ -8,7 +8,9 @@ module.exports = function(callback) {
     Model.User.create({
       username: 'user',
       password: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O9D93HKwPKFNWBqiiuc/IoMtIurRCT36',
-      salt: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O'
+      salt: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O',
+      resetToken: null,
+      resetTokenExpires: null
     }).then(callback)
   })
 }

--- a/views/forgot.handlebars
+++ b/views/forgot.handlebars
@@ -1,0 +1,19 @@
+{{#section 'head'}}
+    <link rel="stylesheet" href="/css/auth.css">
+{{/section}}
+
+<div class="container">
+  <form method="POST" action="/forgot" class="form-signin">
+    <h2 class="form-signin-heading">Reset password</h2>
+
+    {{#if errorMessage}}
+      <div class="alert alert-danger">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    <label for="inputUsername" class="sr-only">Username</label>
+    <input type="text" id="inputUsername" name="username" class="form-control" placeholder="Username" required autofocus>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Send reset link</button>
+  </form>
+</div>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -18,5 +18,6 @@
     <input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required>
     <button class="btn btn-lg btn-primary btn-block" type="submit">Log in</button>
     <a href="/signup" class="btn btn-lg btn-primary btn-block">Register</a>
+    <a href="/forgot" class="btn btn-lg btn-default btn-block">Forgot password?</a>
   </form>
 </div>

--- a/views/reset.handlebars
+++ b/views/reset.handlebars
@@ -1,0 +1,21 @@
+{{#section 'head'}}
+    <link rel="stylesheet" href="/css/auth.css">
+{{/section}}
+
+<div class="container">
+  <form method="POST" action="/reset/{{token}}" class="form-signin">
+    <h2 class="form-signin-heading">Enter new password</h2>
+
+    {{#if errorMessage}}
+      <div class="alert alert-danger">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    <label for="inputPassword" class="sr-only">Password</label>
+    <input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required autofocus>
+    <label for="inputPassword2" class="sr-only">Repeat Password</label>
+    <input type="password" id="inputPassword2" name="password2" class="form-control" placeholder="Repeat Password" required>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Reset password</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- add controller for password resets
- store reset token fields in the `User` model
- expose `/forgot` and `/reset/:token` routes
- link to the reset page from the login form
- document new routes in the README

## Testing
- `npx nightwatch` *(fails: Error: canceled)*

------
https://chatgpt.com/codex/tasks/task_e_68428161efc883299620230047e7b0c1