### PR TITLE
Add email-based password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,24 @@ Visit `http://localhost:3000` to see the login page. The main routes are:
 
 - `/` – log in
 - `/signup` – registration form
+- `/forgot` – request password reset
+- `/reset/:token` – set a new password
 - `/dashboard` – protected dashboard (requires authentication)
 - `/logout` – end the session
+
+### Email configuration
+
+If you set the following environment variables, a reset link will be emailed to
+users who request a password reset:
+
+- `MAIL_HOST` – SMTP server hostname
+- `MAIL_PORT` – SMTP port (defaults to 587)
+- `MAIL_USER` – SMTP username
+- `MAIL_PASS` – SMTP password
+- `MAIL_FROM` – address to send emails from (defaults to `MAIL_USER`)
+
+If these variables are not configured, the reset link is printed to the server
+console instead.
 
 ## Testing
 

--- a/app/controllers/passwordResetController.js
+++ b/app/controllers/passwordResetController.js
@@ -1,0 +1,112 @@
+const crypto = require('crypto');
+const bcrypt = require('bcrypt');
+const nodemailer = require('nodemailer');
+const Model = require('../model/models.js');
+
+function sendResetEmail(email, token) {
+  const url = `http://localhost:3000/reset/${token}`;
+  if (!process.env.MAIL_HOST) {
+    console.log('Password reset link:', url);
+    return Promise.resolve();
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.MAIL_HOST,
+    port: Number(process.env.MAIL_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.MAIL_USER,
+      pass: process.env.MAIL_PASS
+    }
+  });
+
+  return transporter.sendMail({
+    from: process.env.MAIL_FROM || process.env.MAIL_USER,
+    to: email,
+    subject: 'Password reset',
+    text: `Reset your password here: ${url}`
+  });
+}
+
+module.exports.showForgot = function(req, res) {
+  res.render('forgot');
+};
+
+module.exports.handleForgot = function(req, res) {
+  const username = req.body.username;
+  if (!username) {
+    req.flash('error', 'Please provide a username.');
+    return res.redirect('/forgot');
+  }
+  Model.User.findOne({ where: { username } }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'No user found.');
+      return res.redirect('/forgot');
+    }
+    const token = crypto.randomBytes(20).toString('hex');
+    const expires = Date.now() + 3600000; // 1 hour
+    user.resetToken = token;
+    user.resetTokenExpires = new Date(expires);
+    user.save().then(function() {
+      sendResetEmail(user.email, token)
+        .then(function() {
+          req.flash('error', 'Password reset instructions sent.');
+          res.redirect('/');
+        })
+        .catch(function(err) {
+          console.error('Failed to send reset email:', err);
+          req.flash('error', 'Unable to send reset email. Check server logs.');
+          res.redirect('/');
+        });
+    });
+  });
+};
+
+module.exports.showReset = function(req, res) {
+  Model.User.findOne({
+    where: {
+      resetToken: req.params.token,
+      resetTokenExpires: { $gt: new Date() }
+    }
+  }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'Password reset token is invalid or has expired.');
+      return res.redirect('/forgot');
+    }
+    res.render('reset', { token: req.params.token });
+  });
+};
+
+module.exports.handleReset = function(req, res) {
+  const password = req.body.password;
+  const password2 = req.body.password2;
+  if (!password || !password2) {
+    req.flash('error', 'Please fill in all fields.');
+    return res.redirect('back');
+  }
+  if (password !== password2) {
+    req.flash('error', 'Passwords do not match.');
+    return res.redirect('back');
+  }
+  Model.User.findOne({
+    where: {
+      resetToken: req.params.token,
+      resetTokenExpires: { $gt: new Date() }
+    }
+  }).then(function(user) {
+    if (!user) {
+      req.flash('error', 'Password reset token is invalid or has expired.');
+      return res.redirect('/forgot');
+    }
+    const salt = bcrypt.genSaltSync(10);
+    const hashedPassword = bcrypt.hashSync(password, salt);
+    user.password = hashedPassword;
+    user.salt = salt;
+    user.resetToken = null;
+    user.resetTokenExpires = null;
+    user.save().then(function() {
+      req.flash('error', 'Password has been reset.');
+      res.redirect('/');
+    });
+  });
+};

--- a/app/model/User.js
+++ b/app/model/User.js
@@ -26,6 +26,12 @@ var attributes = {
   },
   salt: {
     type: Sequelize.STRING
+  },
+  resetToken: {
+    type: Sequelize.STRING
+  },
+  resetTokenExpires: {
+    type: Sequelize.DATE
   }
 }
 

--- a/app/routers/appRouter.js
+++ b/app/routers/appRouter.js
@@ -1,5 +1,6 @@
 var passport = require('passport'),
-    signupController = require('../controllers/signupController.js')
+    signupController = require('../controllers/signupController.js'),
+    passwordResetController = require('../controllers/passwordResetController.js')
 
 module.exports = function(express) {
   var router = express.Router()
@@ -13,6 +14,11 @@ module.exports = function(express) {
   
   router.get('/signup', signupController.show)
   router.post('/signup', signupController.signup)
+
+  router.get('/forgot', passwordResetController.showForgot)
+  router.post('/forgot', passwordResetController.handleForgot)
+  router.get('/reset/:token', passwordResetController.showReset)
+  router.post('/reset/:token', passwordResetController.handleReset)
 
   router.post('/login', passport.authenticate('local', {
       successRedirect: '/dashboard',

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "express-handlebars": "^8.0.1",
         "express-session": "^1.18.1",
         "mysql2": "^3.9.7",
+        "nodemailer": "^6.9.8",
         "passport": "^0.7.0",
         "passport-local": "^1.0.0",
         "sequelize": "^6.37.7"
@@ -1390,6 +1391,15 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.8",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.8.tgz",
+      "integrity": "sha512-cfrYUk16e67Ks051i4CntM9kshRYei1/o/Gi8K1d+R34OIs21xdFnW7Pt7EucmVKA0LKtqUGNcjMZ7ehjl49mQ==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nopt": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "express-handlebars": "^8.0.1",
     "express-session": "^1.18.1",
     "mysql2": "^3.9.7",
+    "nodemailer": "^6.9.8",
     "passport": "^0.7.0",
     "passport-local": "^1.0.0",
     "sequelize": "^6.37.7"

--- a/tests/utils/cleanup.js
+++ b/tests/utils/cleanup.js
@@ -7,8 +7,11 @@ module.exports = function(callback) {
     // password: user
     Model.User.create({
       username: 'user',
+      email: 'user@example.com',
       password: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O9D93HKwPKFNWBqiiuc/IoMtIurRCT36',
-      salt: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O'
+      salt: '$2a$10$QaT1MdQ2DRWuvIxtNQ1i5O',
+      resetToken: null,
+      resetTokenExpires: null
     }).then(callback)
   })
 }

--- a/views/forgot.handlebars
+++ b/views/forgot.handlebars
@@ -1,0 +1,19 @@
+{{#section 'head'}}
+    <link rel="stylesheet" href="/css/auth.css">
+{{/section}}
+
+<div class="container">
+  <form method="POST" action="/forgot" class="form-signin">
+    <h2 class="form-signin-heading">Reset password</h2>
+
+    {{#if errorMessage}}
+      <div class="alert alert-danger">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    <label for="inputUsername" class="sr-only">Username</label>
+    <input type="text" id="inputUsername" name="username" class="form-control" placeholder="Username" required autofocus>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Send reset link</button>
+  </form>
+</div>

--- a/views/home.handlebars
+++ b/views/home.handlebars
@@ -18,5 +18,6 @@
     <input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required>
     <button class="btn btn-lg btn-primary btn-block" type="submit">Log in</button>
     <a href="/signup" class="btn btn-lg btn-primary btn-block">Register</a>
+    <a href="/forgot" class="btn btn-lg btn-default btn-block">Forgot password?</a>
   </form>
 </div>

--- a/views/reset.handlebars
+++ b/views/reset.handlebars
@@ -1,0 +1,21 @@
+{{#section 'head'}}
+    <link rel="stylesheet" href="/css/auth.css">
+{{/section}}
+
+<div class="container">
+  <form method="POST" action="/reset/{{token}}" class="form-signin">
+    <h2 class="form-signin-heading">Enter new password</h2>
+
+    {{#if errorMessage}}
+      <div class="alert alert-danger">
+        {{errorMessage}}
+      </div>
+    {{/if}}
+
+    <label for="inputPassword" class="sr-only">Password</label>
+    <input type="password" id="inputPassword" name="password" class="form-control" placeholder="Password" required autofocus>
+    <label for="inputPassword2" class="sr-only">Repeat Password</label>
+    <input type="password" id="inputPassword2" name="password2" class="form-control" placeholder="Repeat Password" required>
+    <button class="btn btn-lg btn-primary btn-block" type="submit">Reset password</button>
+  </form>
+</div>


### PR DESCRIPTION
## Summary
- send password reset links by email when SMTP variables are set
- allow storing default user's email for tests
- document email configuration in README
- include nodemailer dependency

## Testing
- `npx nightwatch` *(fails: needs to install nightwatch)*

------
https://chatgpt.com/codex/tasks/task_e_68428161efc883299620230047e7b0c1