### PR TITLE
Fix auth flow validation and password reset handling

### DIFF
--- a/app/controllers/passwordResetController.js
+++ b/app/controllers/passwordResetController.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const bcrypt = require('bcrypt');
+const { Op } = require('sequelize');
 const Model = require('../model/models.js');
 
 module.exports.showForgot = function(req, res) {
@@ -33,7 +34,7 @@ module.exports.showReset = function(req, res) {
   Model.User.findOne({
     where: {
       resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {
@@ -58,7 +59,7 @@ module.exports.handleReset = function(req, res) {
   Model.User.findOne({
     where: {
       resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {

--- a/app/controllers/signupController.js
+++ b/app/controllers/signupController.js
@@ -12,12 +12,12 @@ module.exports.signup = function(req, res) {
   
   if (!username || !password || !password2) {
     req.flash('error', "Please, fill in all the fields.")
-    res.redirect('signup')
+    return res.redirect('/signup')
   }
   
   if (password !== password2) {
     req.flash('error', "Please, enter the same password twice.")
-    res.redirect('signup')
+    return res.redirect('/signup')
   }
   
   var salt = bcrypt.genSaltSync(10)

--- a/app/routers/appRouter.js
+++ b/app/routers/appRouter.js
@@ -9,7 +9,7 @@ module.exports = function(express) {
     if (req.isAuthenticated())
       return next()
     req.flash('error', 'You have to be logged in to access the page.')
-    res.redirect('/')
+    return res.redirect('/')
   }
   
   router.get('/signup', signupController.show)
@@ -35,8 +35,13 @@ module.exports = function(express) {
   })
 
   router.get('/logout', function(req, res) {
-    req.logout()
-    res.redirect('/')
+    req.logout(function(err) {
+      if (err) {
+        req.flash('error', 'Logout failed.')
+        return res.redirect('/')
+      }
+      res.redirect('/')
+    })
   })
 
   return router

--- a/app/setupPassport.js
+++ b/app/setupPassport.js
@@ -18,13 +18,15 @@ module.exports = function(app) {
           return done(null, false, { message: 'Incorrect credentials.' })
         }
         
-        var hashedPassword = bcrypt.hashSync(password, user.salt)
-        
-        if (user.password === hashedPassword) {
+        var isValid = bcrypt.compareSync(password, user.password)
+
+        if (isValid) {
           return done(null, user)
         }
         
         return done(null, false, { message: 'Incorrect credentials.' })
+      }).catch(function (error) {
+        return done(error)
       })
     }
   ))
@@ -40,10 +42,12 @@ module.exports = function(app) {
       }
     }).then(function (user) {
       if (user == null) {
-        done(new Error('Wrong user id.'))
+        return done(new Error('Wrong user id.'))
       }
       
       done(null, user)
+    }).catch(function (error) {
+      done(error)
     })
   })
 }


### PR DESCRIPTION
### Motivation
- Fix several runtime errors and logic bugs in the authentication and password-reset flows that prevented correct validation, token expiry checks, and safe session handling.

### Description
- Stop signup processing on validation failures and use the correct redirect path by returning early from `signup` in `app/controllers/signupController.js`.
- Replace legacy Sequelize comparison syntax with `Op.gt` for `resetTokenExpires` checks in `app/controllers/passwordResetController.js` and import `{ Op }` from `sequelize`.
- Harden Passport flows in `app/setupPassport.js` by using `bcrypt.compareSync` for password verification, adding `.catch` error handling to callbacks, and returning the error when `deserializeUser` fails.
- Align logout behavior with newer Passport APIs and ensure control flow returns in `app/routers/appRouter.js` by using the async `req.logout(function(err) { ... })` callback and returning from redirects where appropriate.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e621bb468832995bb4bed85bcd930)