### PR TITLE
Rewrite README and harden authentication and password-reset flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,53 @@
-# Express Passport Sequelize MySQL Example
+# Express + Passport + Sequelize + MySQL Example
 
-This project demonstrates a simple authentication flow using [Express](https://expressjs.com/), [Passport](http://www.passportjs.org/), and [Sequelize](https://sequelize.org/). It stores user information in a MySQL database and renders pages with Handlebars templates.
+This project demonstrates a simple authentication flow built with Express, Passport, and Sequelize, using MySQL for persistence and Handlebars for server-rendered views. It includes signup, login, password reset, and a protected dashboard.
+
+## Features
+
+- Local username/password authentication with Passport
+- Password reset flow (token printed to the server console)
+- Sequelize model for user data stored in MySQL
+- Simple Handlebars templates for UI
+- Nightwatch end-to-end tests
 
 ## Prerequisites
 
-- Node.js 18 or later
-- A running MySQL instance
+- Node.js 18+
+- MySQL 8+ (or compatible)
 
-## Setup
+## Quick Start
 
 1. Install dependencies:
    ```bash
    npm install
    ```
-2. Adjust the database settings in `app/sequelize.js` to match your environment.
-3. Create the database schema and a default user:
+
+2. Configure the database connection in `app/sequelize.js`:
+   ```js
+   // new Sequelize('database', 'user', 'password', { host: 'localhost', dialect: 'mysql' })
+   ```
+   Update the database name, username, and password to match your local MySQL setup.
+
+3. Create the database and seed a default user:
    ```bash
    node setup.js
    ```
+   This recreates the `users` table and inserts a default user.
 
-## Running the Server
+4. Start the server:
+   ```bash
+   npm start
+   ```
 
-Start the application with:
-```bash
-npm start
-```
-Then open `http://localhost:3000` in your browser.
+5. Visit the app:
+   - http://localhost:3000
+
+## Default Credentials
+
+After running `node setup.js`, you can sign in with:
+
+- **Username:** `user`
+- **Password:** `user`
 
 ## Application Routes
 
@@ -36,12 +58,24 @@ Then open `http://localhost:3000` in your browser.
 - `/dashboard` – protected dashboard (requires login)
 - `/logout` – sign out
 
+## Password Reset Notes
+
+When requesting a password reset from `/forgot`, the app prints a reset link to the server console. Copy the URL into your browser to continue the reset flow.
+
 ## Tests
 
-Nightwatch end‑to‑end tests are located in the `tests` directory. To run them, make sure Selenium is configured in `nightwatch.json` and execute:
-```bash
-npx nightwatch
-```
+Nightwatch end‑to‑end tests are located in the `tests` directory. To run them:
+
+1. Ensure Selenium is configured in `nightwatch.json`.
+2. Execute:
+   ```bash
+   npx nightwatch
+   ```
+
+## Troubleshooting
+
+- **Database connection errors:** Verify the credentials in `app/sequelize.js` and confirm the database exists.
+- **Port conflicts:** Set a custom port with `PORT=4000 npm start`.
 
 ## License
 

--- a/app/controllers/passwordResetController.js
+++ b/app/controllers/passwordResetController.js
@@ -1,5 +1,6 @@
 const crypto = require('crypto');
 const bcrypt = require('bcrypt');
+const { Op } = require('sequelize');
 const Model = require('../model/models.js');
 
 module.exports.showForgot = function(req, res) {
@@ -33,7 +34,7 @@ module.exports.showReset = function(req, res) {
   Model.User.findOne({
     where: {
       resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {
@@ -58,7 +59,7 @@ module.exports.handleReset = function(req, res) {
   Model.User.findOne({
     where: {
       resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {

--- a/app/controllers/signupController.js
+++ b/app/controllers/signupController.js
@@ -12,12 +12,12 @@ module.exports.signup = function(req, res) {
   
   if (!username || !password || !password2) {
     req.flash('error', "Please, fill in all the fields.")
-    res.redirect('signup')
+    return res.redirect('/signup')
   }
   
   if (password !== password2) {
     req.flash('error', "Please, enter the same password twice.")
-    res.redirect('signup')
+    return res.redirect('/signup')
   }
   
   var salt = bcrypt.genSaltSync(10)

--- a/app/routers/appRouter.js
+++ b/app/routers/appRouter.js
@@ -9,7 +9,7 @@ module.exports = function(express) {
     if (req.isAuthenticated())
       return next()
     req.flash('error', 'You have to be logged in to access the page.')
-    res.redirect('/')
+    return res.redirect('/')
   }
   
   router.get('/signup', signupController.show)
@@ -35,8 +35,13 @@ module.exports = function(express) {
   })
 
   router.get('/logout', function(req, res) {
-    req.logout()
-    res.redirect('/')
+    req.logout(function(err) {
+      if (err) {
+        req.flash('error', 'Logout failed.')
+        return res.redirect('/')
+      }
+      res.redirect('/')
+    })
   })
 
   return router

--- a/app/setupPassport.js
+++ b/app/setupPassport.js
@@ -18,13 +18,15 @@ module.exports = function(app) {
           return done(null, false, { message: 'Incorrect credentials.' })
         }
         
-        var hashedPassword = bcrypt.hashSync(password, user.salt)
-        
-        if (user.password === hashedPassword) {
+        var isValid = bcrypt.compareSync(password, user.password)
+
+        if (isValid) {
           return done(null, user)
         }
         
         return done(null, false, { message: 'Incorrect credentials.' })
+      }).catch(function (error) {
+        return done(error)
       })
     }
   ))
@@ -40,10 +42,12 @@ module.exports = function(app) {
       }
     }).then(function (user) {
       if (user == null) {
-        done(new Error('Wrong user id.'))
+        return done(new Error('Wrong user id.'))
       }
       
       done(null, user)
+    }).catch(function (error) {
+      done(error)
     })
   })
 }


### PR DESCRIPTION
### Motivation
- Improve developer onboarding by providing clearer installation, configuration, and usage instructions in the README.
- Fix runtime and logic issues in authentication and password-reset flows to prevent token expiry, validation, and logout errors.

### Description
- Replace legacy Sequelize comparison syntax with `Op.gt` and import `{ Op }` in `app/controllers/passwordResetController.js` to correctly check `resetTokenExpires` values.
- Stop signup processing on validation failures and use the correct redirect path by returning early from `signup` in `app/controllers/signupController.js`.
- Harden Passport flows in `app/setupPassport.js` by using `bcrypt.compareSync` for password verification, adding `.catch` error handling to promises, and returning the error when `deserializeUser` fails.
- Align logout and auth guard behavior in `app/routers/appRouter.js` by returning redirects, using the async `req.logout(function(err) { ... })` callback, and handling logout errors.
- Replace the project `README.md` with a full Quick Start that includes features, prerequisites, configuration guidance for `app/sequelize.js`, default credentials, routes, password-reset notes, testing instructions, and troubleshooting tips.

### Testing
- No automated tests were executed for these changes.
- Nightwatch end-to-end tests are documented in the updated `README.md`, but were not run as part of this change.
- Manual validation consisted of reviewing the code diffs to ensure proper control flow and error handling were added.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e621bb468832995bb4bed85bcd930)