### PR TITLE
Enhance security and auth flows (sessions, password reset, signup) and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,59 @@
-# Express Passport Sequelize MySQL Example
+# Express + Passport + Sequelize + MySQL Example
 
-This project demonstrates a simple authentication flow using [Express](https://expressjs.com/), [Passport](http://www.passportjs.org/), and [Sequelize](https://sequelize.org/). It stores user information in a MySQL database and renders pages with Handlebars templates.
+This project demonstrates a simple authentication flow built with Express, Passport, and Sequelize, using MySQL for persistence and Handlebars for server-rendered views. It includes signup, login, password reset, and a protected dashboard.
+
+## Features
+
+- Local username/password authentication with Passport
+- Password reset flow (token printed to the server console)
+- Sequelize model for user data stored in MySQL
+- Simple Handlebars templates for UI
+- Nightwatch end-to-end tests
 
 ## Prerequisites
 
-- Node.js 18 or later
-- A running MySQL instance
+- Node.js 18+
+- MySQL 8+ (or compatible)
 
-## Setup
+## Quick Start
 
 1. Install dependencies:
    ```bash
    npm install
    ```
-2. Adjust the database settings in `app/sequelize.js` to match your environment.
-3. Create the database schema and a default user:
+
+2. Configure the database connection in `app/sequelize.js`:
+   ```js
+   // new Sequelize('database', 'user', 'password', { host: 'localhost', dialect: 'mysql' })
+   ```
+   Update the database name, username, and password to match your local MySQL setup.
+
+3. Set a strong session secret:
+   ```bash
+   export SESSION_SECRET="replace-with-a-long-random-secret"
+   ```
+   In production, always set `NODE_ENV=production` and use HTTPS so secure cookies are enforced.
+
+4. Create the database and seed a default user:
    ```bash
    node setup.js
    ```
+   This recreates the `users` table and inserts a default user.
 
-## Running the Server
+5. Start the server:
+   ```bash
+   npm start
+   ```
 
-Start the application with:
-```bash
-npm start
-```
-Then open `http://localhost:3000` in your browser.
+6. Visit the app:
+   - http://localhost:3000
+
+## Default Credentials
+
+After running `node setup.js`, you can sign in with:
+
+- **Username:** `user`
+- **Password:** `user`
 
 ## Application Routes
 
@@ -34,14 +62,27 @@ Then open `http://localhost:3000` in your browser.
 - `/forgot` – request password reset (token printed to console)
 - `/reset/:token` – set a new password
 - `/dashboard` – protected dashboard (requires login)
-- `/logout` – sign out
+- `/logout` – sign out (supports `POST` and `GET`; prefer `POST`)
+
+## Password Reset Notes
+
+When requesting a password reset from `/forgot`, the app prints a reset link to the server console. Copy the URL into your browser to continue the reset flow.
 
 ## Tests
 
-Nightwatch end‑to‑end tests are located in the `tests` directory. To run them, make sure Selenium is configured in `nightwatch.json` and execute:
-```bash
-npx nightwatch
-```
+Nightwatch end‑to‑end tests are located in the `tests` directory. To run them:
+
+1. Ensure Selenium is configured in `nightwatch.json`.
+2. Execute:
+   ```bash
+   npx nightwatch
+   ```
+
+## Troubleshooting
+
+- **Database connection errors:** Verify the credentials in `app/sequelize.js` and confirm the database exists.
+- **Port conflicts:** Set a custom port with `PORT=4000 npm start`.
+- **Security warning:** If `SESSION_SECRET` is not set, the app uses a development fallback and prints a warning on startup.
 
 ## License
 

--- a/app.js
+++ b/app.js
@@ -12,9 +12,34 @@ var express = require('express'),
     jsonParser = bodyParser.json()
 
 var port = process.env.PORT || 3000
+var isProduction = process.env.NODE_ENV === 'production'
+var sessionSecret = process.env.SESSION_SECRET
+
+if (!sessionSecret) {
+  sessionSecret = 'development-only-secret-change-me'
+  console.warn('SESSION_SECRET is not set. Falling back to an insecure development secret.')
+}
 
 app.use(cookieParser())
-app.use(session({ secret: '4564f6s4fdsfdfd', resave: false, saveUninitialized: false }))
+app.use(session({
+  name: 'sid',
+  secret: sessionSecret,
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    httpOnly: true,
+    sameSite: 'lax',
+    secure: isProduction,
+    maxAge: 1000 * 60 * 60 * 12 // 12 hours
+  }
+}))
+
+app.use(function(req, res, next) {
+  res.setHeader('X-Content-Type-Options', 'nosniff')
+  res.setHeader('X-Frame-Options', 'DENY')
+  res.setHeader('Referrer-Policy', 'no-referrer')
+  next()
+})
 
 app.use(express.static('app/public'));
 

--- a/app/controllers/passwordResetController.js
+++ b/app/controllers/passwordResetController.js
@@ -1,46 +1,63 @@
 const crypto = require('crypto');
 const bcrypt = require('bcrypt');
+const { Op } = require('sequelize');
 const Model = require('../model/models.js');
+
+const RESET_TOKEN_TTL_MS = 60 * 60 * 1000;
+const MIN_PASSWORD_LENGTH = 8;
+
+function hashResetToken(token) {
+  return crypto.createHash('sha256').update(token).digest('hex');
+}
 
 module.exports.showForgot = function(req, res) {
   res.render('forgot');
 };
 
 module.exports.handleForgot = function(req, res) {
-  const username = req.body.username;
+  const username = (req.body.username || '').trim();
   if (!username) {
     req.flash('error', 'Please provide a username.');
     return res.redirect('/forgot');
   }
   Model.User.findOne({ where: { username } }).then(function(user) {
-    if (!user) {
-      req.flash('error', 'No user found.');
-      return res.redirect('/forgot');
+    if (user) {
+      const token = crypto.randomBytes(32).toString('hex');
+      const expires = Date.now() + RESET_TOKEN_TTL_MS;
+
+      user.resetToken = hashResetToken(token);
+      user.resetTokenExpires = new Date(expires);
+
+      return user.save().then(function() {
+        console.log('Password reset link: http://localhost:3000/reset/' + token);
+      });
     }
-    const token = crypto.randomBytes(20).toString('hex');
-    const expires = Date.now() + 3600000; // 1 hour
-    user.resetToken = token;
-    user.resetTokenExpires = new Date(expires);
-    user.save().then(function() {
-      console.log('Password reset link: http://localhost:3000/reset/' + token);
-      req.flash('error', 'Check console for reset link.');
-      res.redirect('/');
-    });
+  }).then(function() {
+    req.flash('error', 'If an account exists, a reset link has been generated.');
+    return res.redirect('/');
+  }).catch(function() {
+    req.flash('error', 'Unable to process password reset right now.');
+    return res.redirect('/forgot');
   });
 };
 
 module.exports.showReset = function(req, res) {
+  const tokenHash = hashResetToken(req.params.token);
+
   Model.User.findOne({
     where: {
-      resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetToken: tokenHash,
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {
       req.flash('error', 'Password reset token is invalid or has expired.');
       return res.redirect('/forgot');
     }
-    res.render('reset', { token: req.params.token });
+    return res.render('reset', { token: req.params.token });
+  }).catch(function() {
+    req.flash('error', 'Unable to validate reset token.');
+    return res.redirect('/forgot');
   });
 };
 
@@ -55,10 +72,16 @@ module.exports.handleReset = function(req, res) {
     req.flash('error', 'Passwords do not match.');
     return res.redirect('back');
   }
+  if (password.length < MIN_PASSWORD_LENGTH) {
+    req.flash('error', 'Password must be at least 8 characters long.');
+    return res.redirect('back');
+  }
+  const tokenHash = hashResetToken(req.params.token);
+
   Model.User.findOne({
     where: {
-      resetToken: req.params.token,
-      resetTokenExpires: { $gt: new Date() }
+      resetToken: tokenHash,
+      resetTokenExpires: { [Op.gt]: new Date() }
     }
   }).then(function(user) {
     if (!user) {
@@ -71,9 +94,12 @@ module.exports.handleReset = function(req, res) {
     user.salt = salt;
     user.resetToken = null;
     user.resetTokenExpires = null;
-    user.save().then(function() {
+    return user.save().then(function() {
       req.flash('error', 'Password has been reset.');
-      res.redirect('/');
+      return res.redirect('/');
     });
+  }).catch(function() {
+    req.flash('error', 'Unable to reset password right now.');
+    return res.redirect('/forgot');
   });
 };

--- a/app/controllers/signupController.js
+++ b/app/controllers/signupController.js
@@ -6,18 +6,23 @@ module.exports.show = function(req, res) {
 }
 
 module.exports.signup = function(req, res) {
-  var username = req.body.username
+  var username = (req.body.username || '').trim()
   var password = req.body.password
   var password2 = req.body.password2
   
   if (!username || !password || !password2) {
     req.flash('error', "Please, fill in all the fields.")
-    res.redirect('signup')
+    return res.redirect('/signup')
   }
   
   if (password !== password2) {
     req.flash('error', "Please, enter the same password twice.")
-    res.redirect('signup')
+    return res.redirect('/signup')
+  }
+
+  if (password.length < 8) {
+    req.flash('error', 'Password must be at least 8 characters long.')
+    return res.redirect('/signup')
   }
   
   var salt = bcrypt.genSaltSync(10)

--- a/app/routers/appRouter.js
+++ b/app/routers/appRouter.js
@@ -4,12 +4,24 @@ var passport = require('passport'),
 
 module.exports = function(express) {
   var router = express.Router()
+  var performLogout = function(req, res) {
+    req.logout(function(err) {
+      if (err) {
+        req.flash('error', 'Logout failed.')
+        return res.redirect('/')
+      }
+      req.session.destroy(function() {
+        res.clearCookie('sid')
+        return res.redirect('/')
+      })
+    })
+  }
 
   var isAuthenticated = function (req, res, next) {
     if (req.isAuthenticated())
       return next()
     req.flash('error', 'You have to be logged in to access the page.')
-    res.redirect('/')
+    return res.redirect('/')
   }
   
   router.get('/signup', signupController.show)
@@ -34,10 +46,8 @@ module.exports = function(express) {
     res.render('dashboard')
   })
 
-  router.get('/logout', function(req, res) {
-    req.logout()
-    res.redirect('/')
-  })
+  router.post('/logout', isAuthenticated, performLogout)
+  router.get('/logout', isAuthenticated, performLogout)
 
   return router
 }

--- a/app/setupPassport.js
+++ b/app/setupPassport.js
@@ -18,13 +18,15 @@ module.exports = function(app) {
           return done(null, false, { message: 'Incorrect credentials.' })
         }
         
-        var hashedPassword = bcrypt.hashSync(password, user.salt)
-        
-        if (user.password === hashedPassword) {
+        var isValid = bcrypt.compareSync(password, user.password)
+
+        if (isValid) {
           return done(null, user)
         }
         
         return done(null, false, { message: 'Incorrect credentials.' })
+      }).catch(function (error) {
+        return done(error)
       })
     }
   ))
@@ -40,10 +42,12 @@ module.exports = function(app) {
       }
     }).then(function (user) {
       if (user == null) {
-        done(new Error('Wrong user id.'))
+        return done(new Error('Wrong user id.'))
       }
       
       done(null, user)
+    }).catch(function (error) {
+      done(error)
     })
   })
 }


### PR DESCRIPTION
### Motivation

- Harden session handling and cookie settings to be safer in production environments.  
- Improve password reset and signup flows to avoid leaking account existence and to enforce stronger passwords.  
- Fix authentication logic to use secure password comparison and add better error handling.  

### Description

- Update `app.js` to read `SESSION_SECRET` and fall back to a development secret with a console warning, set the session cookie name to `sid`, and configure cookie options including `httpOnly`, `sameSite: 'lax'`, `secure` when `NODE_ENV=production`, and a 12-hour `maxAge`, and add security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`).  
- Replace manual password hashing comparison in `setupPassport.js` with `bcrypt.compareSync` and add promise `.catch` paths for errors, and ensure `deserializeUser` returns errors consistently.  
- Improve signup validation in `signupController.js` by trimming the username, enforcing a minimum password length of 8, returning early on validation failures, and preserving error flash messages.  
- Rework password reset in `passwordResetController.js` to generate cryptographically strong tokens, store only a SHA-256 hash of the token, enforce a one-hour TTL (`RESET_TOKEN_TTL_MS`), use Sequelize `Op.gt` for expiry checks, validate token existence safely (no account enumeration), enforce minimum password length on reset, and add error handling with informative flash messages.  
- Update routes in `appRouter.js` to require authentication for logout, support both `POST` and `GET` logout routes, and perform a proper logout that calls `req.logout` with a callback, destroys the session, and clears the `sid` cookie.  
- Refresh `README.md` with clearer quick-start instructions, features list, default credentials, password-reset notes, testing guidance, and troubleshooting tips.  

### Testing

- No automated tests were executed as part of this change; existing Nightwatch end-to-end tests remain available in `tests` and can be run with `npx nightwatch` after configuring `nightwatch.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_697e621bb468832995bb4bed85bcd930)